### PR TITLE
Refactor Address and ProductEntity classes, add ProductPersistenceMapper and ProductRepository

### DIFF
--- a/src/main/java/ar/edu/unlp/pas/product/domain/models/Address.java
+++ b/src/main/java/ar/edu/unlp/pas/product/domain/models/Address.java
@@ -1,5 +1,6 @@
 package ar.edu.unlp.pas.product.domain.models;
-import javax.persistence.Entity;
+import javax.persistence.*;
+
 import lombok.Data;
 
 @Data
@@ -16,6 +17,8 @@ public class Address {
     private String city;
     private String province;
     private String country;
+
+
 
 }
 

--- a/src/main/java/ar/edu/unlp/pas/product/infraestructure/adapters/output/persistence/entity/ProductEntity.java
+++ b/src/main/java/ar/edu/unlp/pas/product/infraestructure/adapters/output/persistence/entity/ProductEntity.java
@@ -1,15 +1,6 @@
 package ar.edu.unlp.pas.product.infraestructure.adapters.output.persistence.entity;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 import ar.edu.unlp.pas.product.domain.models.Address;
@@ -39,7 +30,7 @@ public class ProductEntity {
     @Column(name = "category")
     private String category;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @JoinColumn(name = "address_id")
     private Address address;
 }

--- a/src/main/java/ar/edu/unlp/pas/product/infraestructure/adapters/output/persistence/mapper/ProductPersistenceMapper.java
+++ b/src/main/java/ar/edu/unlp/pas/product/infraestructure/adapters/output/persistence/mapper/ProductPersistenceMapper.java
@@ -1,0 +1,11 @@
+package ar.edu.unlp.pas.product.infraestructure.adapters.output.persistence.mapper;
+
+import ar.edu.unlp.pas.product.domain.models.Product;
+import ar.edu.unlp.pas.product.infraestructure.adapters.output.persistence.entity.ProductEntity;
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface ProductPersistenceMapper {
+    ProductEntity toProductEntity(Product product);
+    Product toProduct(ProductEntity productEntity);
+}

--- a/src/main/java/ar/edu/unlp/pas/product/infraestructure/adapters/output/persistence/repository/ProductRepository.java
+++ b/src/main/java/ar/edu/unlp/pas/product/infraestructure/adapters/output/persistence/repository/ProductRepository.java
@@ -1,0 +1,11 @@
+package ar.edu.unlp.pas.product.infraestructure.adapters.output.persistence.repository;
+
+import ar.edu.unlp.pas.product.infraestructure.adapters.output.persistence.entity.ProductEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<ProductEntity,Long> {
+
+}
+


### PR DESCRIPTION
- Refactored the Address class to import javax.persistence.*
- Refactored the ProductEntity class to change the relationship between address and product from ManyToOne to OneToOne
- Added a new file, ProductPersistenceMapper.java, which contains a mapper interface for converting between Product and ProductEntity objects
- Added a new file, ProductRepository.java, which is an interface extending JpaRepository for managing persistence operations on ProductEntity objects